### PR TITLE
libcore: add a way to clear cached time zone strings

### DIFF
--- a/luni/src/main/java/libcore/icu/TimeZoneNames.java
+++ b/luni/src/main/java/libcore/icu/TimeZoneNames.java
@@ -135,6 +135,18 @@ public final class TimeZoneNames {
     }
 
     /**
+     * Clear the cached zone strings for {@link Locale#getDefault()}.
+     * Does nothing if it returns {@link Locale#US} or {@link Locale#ROOT}.
+     */
+    public static void clearLocaleCache() {
+        Locale locale = Locale.getDefault();
+        if (locale.equals(Locale.US) || locale.equals(Locale.ROOT)) {
+            return;
+        }
+        cachedZoneStrings.remove(locale);
+    }
+
+    /**
      * Returns an array containing the time zone ids in use in the country corresponding to
      * the given locale. This is not necessary for Java API, but is used by telephony as a
      * fallback. We retrieve these strings from zone.tab rather than icu4c because the latter

--- a/luni/src/main/java/libcore/util/BasicLruCache.java
+++ b/luni/src/main/java/libcore/util/BasicLruCache.java
@@ -79,6 +79,13 @@ public class BasicLruCache<K, V> {
         return previous;
     }
 
+    public synchronized final V remove(K key) {
+        if (key == null) {
+            throw new NullPointerException("key == null");
+        }
+        return map.remove(key);
+    }
+
     private void trimToSize(int maxSize) {
         while (map.size() > maxSize) {
             Map.Entry<K, V> toEvict = map.eldest();


### PR DESCRIPTION
Ref: CYNGNOS-453

Change-Id: I5aaf315f0d2b7b039cacb5de135501cea4f7cf0c
Signed-off-by: Roman Birg roman@cyngn.com
